### PR TITLE
Fix iterator invalidation in connector

### DIFF
--- a/components/wr3223/wr3223_connector.cpp
+++ b/components/wr3223/wr3223_connector.cpp
@@ -202,9 +202,11 @@ void WR3223Connector::send_next_request() {
     return;
   }
 
-  for (auto &req : request_map_) {
+  for (auto it = request_map_.begin(); it != request_map_.end(); ) {
+    auto &req = *it;
     // Prüfen, ob die letzte Anfrage vor mindestens 500 ms gesendet wurde
     if (millis() - req.second.last_sent < 500) {
+      ++it;
       continue;
     }
 
@@ -213,7 +215,7 @@ void WR3223Connector::send_next_request() {
       ESP_LOGW(TAG,
                "Kommando %s wurde zu oft nicht beantwortet und wird ignoriert.",
                req.first.c_str());
-      request_map_.erase(req.first);
+      it = request_map_.erase(it);
       continue;
     }
 


### PR DESCRIPTION
## Summary
- fix loop in `send_next_request()` where map entries were erased during ranged iteration

## Testing
- `python -m py_compile components/wr3223/*.py`
- *(failed to compile C++ due to missing ESPHome deps)*

------
https://chatgpt.com/codex/tasks/task_e_684e9b38b5e8832cbd1793d05a54f8d1